### PR TITLE
Add path mapping support

### DIFF
--- a/remove_common/README.md
+++ b/remove_common/README.md
@@ -112,7 +112,7 @@ as the first command.
 Of course, if you snap uses core20 and/or gnome-3-38-2004, or others, you have to replace
 them in the lists.
 
-By default, teh script will scan the *snapcraft.yaml* file for all the *build-snaps*
+By default, the script will scan the *snapcraft.yaml* file for all the *build-snaps*
 entries in it, but it is possible to override this by manually putting the list of snaps
 in the command line (this is a must to preserve compatibility with the old behavior).
 

--- a/remove_common/README.md
+++ b/remove_common/README.md
@@ -117,7 +117,14 @@ entries in it, but it is possible to override this by manually putting the list 
 in the command line (this is a must to preserve compatibility with the old behavior).
 
 You can also add the *-v* argument to have *verbose* output of which files are being removed.
+
 Also, it is possible to add *-e path1 path2 ...* to exclude several paths from being checked.
+
+Finally, you can add *-m base_snap1:path_piece1 base_snap2:path_piece2* to compare files
+from *SNAP_BEING_BUILT/path_piece1/...* with */snap/base_snap1/...*, etc. This is useful
+for *gtk-common-themes*, because the themes are stored directly at *share/...* instead
+of *usr/share/...*, which prevents to find duplicated icons, sounds and themes. Instead,
+by adding *-m gtk-common-themes:usr*, this problem is fixed.
 
 Remember to add this in *each* part that has *stage-packages*. Parts without stage
 packages don't need this. The *build-snaps* statement only needs to be put once, so it's better

--- a/remove_common/remove_common.py
+++ b/remove_common/remove_common.py
@@ -35,12 +35,14 @@ def get_snapcraft_yaml():
 def check_if_exists(folder_list, relative_file_path):
     """ Checks if an specific file does exist in any of the base paths"""
     for folder, map_path in folder_list:
-        print(f"Comparing ${relative_file_path} in {folder} with {map_path}", end="")
+        print(f"Comparing {relative_file_path} in {folder} with {map_path}", end="")
         if (map_path is not None) and relative_file_path.startswith(map_path):
-            relative_file_path = relative_file_path[len(map_path):]
+            relative_file_path2 = relative_file_path[len(map_path):]
             print(f"; relative_file_path changed to {relative_file_path}", end="")
+        else:
+            relative_file_path2 = relative_file_path
         print()
-        check_path = os.path.join(folder, relative_file_path)
+        check_path = os.path.join(folder, relative_file_path2)
         if os.path.exists(check_path):
             return True
     return False

--- a/remove_common/remove_common.py
+++ b/remove_common/remove_common.py
@@ -35,8 +35,11 @@ def get_snapcraft_yaml():
 def check_if_exists(folder_list, relative_file_path):
     """ Checks if an specific file does exist in any of the base paths"""
     for folder, map_path in folder_list:
+        print(f"Comparing ${relative_file_path} in {folder} with {map_path}", end="")
         if (map_path is not None) and relative_file_path.startswith(map_path):
             relative_file_path = relative_file_path[len(map_path):]
+            print(f"; relative_file_path changed to {relative_file_path}", end="")
+        print()
         check_path = os.path.join(folder, relative_file_path)
         if os.path.exists(check_path):
             return True

--- a/remove_common/remove_common.py
+++ b/remove_common/remove_common.py
@@ -35,10 +35,9 @@ def get_snapcraft_yaml():
 def check_if_exists(folder_list, relative_file_path):
     """ Checks if an specific file does exist in any of the base paths"""
     for folder, map_path in folder_list:
-        if map_path is None:
-            check_path = os.path.join(folder, relative_file_path)
-        else:
-            check_path = os.path.join(folder, map_path, relative_file_path)
+        if (map_path is not None) and relative_file_path.starts_with(map_path):
+            relative_file_path = relative_file_path[len(map_path):]
+        check_path = os.path.join(folder, relative_file_path)
         if os.path.exists(check_path):
             return True
     return False
@@ -112,6 +111,8 @@ if __name__ == "__main__":
                 print(f"Warning: The mapping '{map}' points to an undefined extension")
             while elements[1][0] == '/':
                 elements[1] = elements[1][1:]
+            if elements[1][-1] != '/':
+                elements[1] += '/'
             mapping[elements[0]] = elements[1]
 
     if verbose:

--- a/remove_common/remove_common.py
+++ b/remove_common/remove_common.py
@@ -35,7 +35,7 @@ def get_snapcraft_yaml():
 def check_if_exists(folder_list, relative_file_path):
     """ Checks if an specific file does exist in any of the base paths"""
     for folder, map_path in folder_list:
-        if (map_path is not None) and relative_file_path.starts_with(map_path):
+        if (map_path is not None) and relative_file_path.startswith(map_path):
             relative_file_path = relative_file_path[len(map_path):]
         check_path = os.path.join(folder, relative_file_path)
         if os.path.exists(check_path):
@@ -109,6 +109,9 @@ if __name__ == "__main__":
                 sys.exit(1)
             if elements[0] not in extensions:
                 print(f"Warning: The mapping '{map}' points to an undefined extension")
+            if elements[1] == '/':
+                print(f"Invalid mapping for {elements[0]}")
+                sys.exit(2)
             while elements[1][0] == '/':
                 elements[1] = elements[1][1:]
             if elements[1][-1] != '/':

--- a/remove_common/remove_common.py
+++ b/remove_common/remove_common.py
@@ -35,13 +35,10 @@ def get_snapcraft_yaml():
 def check_if_exists(folder_list, relative_file_path):
     """ Checks if an specific file does exist in any of the base paths"""
     for folder, map_path in folder_list:
-        print(f"Comparing {relative_file_path} in {folder} with {map_path}", end="")
         if (map_path is not None) and relative_file_path.startswith(map_path):
             relative_file_path2 = relative_file_path[len(map_path):]
-            print(f"; relative_file_path changed to {relative_file_path}", end="")
         else:
             relative_file_path2 = relative_file_path
-        print()
         check_path = os.path.join(folder, relative_file_path2)
         if os.path.exists(check_path):
             return True
@@ -131,7 +128,6 @@ if __name__ == "__main__":
         map_path = mapping[snap] if snap in mapping else None
         folders.append((path, map_path))
 
-    print(folders)
     install_folder = os.environ["CRAFT_PART_INSTALL"]
 
     main(install_folder, folders, exclude, verbose)


### PR DESCRIPTION
Some snaps, like gtk-common-themes, have their files in a
different layout than in the final filesystem, which prevents
`remove_common` to find some duplicated files. In the case
of gtk-common-themes, the `share` folder is in the root, when
the equivalent folder in the filesystem is at `usr/share`.

This patch allows to specify a piece of path to append, to
allow to fix this problem. For example, for gtk-common-themes,
it is enough with adding `usr` to the paths. This is achieved
by passing

  -m gtk-common-themes:usr

to the program.